### PR TITLE
fix: `LegacyResolver` typing

### DIFF
--- a/.changeset/sweet-signs-dance.md
+++ b/.changeset/sweet-signs-dance.md
@@ -1,0 +1,5 @@
+---
+"eslint-import-context": patch
+---
+
+fix: `LegacyResolver` typing

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,11 +73,19 @@ export type LegacyResolverResolve<T = unknown> = (
   config: T,
 ) => ResolvedResult
 
-export interface LegacyResolver<T = unknown, U = T> {
-  interfaceVersion?: 1 | 2
-  resolve?: LegacyResolverResolve<T>
-  resolveImport?: LegacyResolverResolveImport<U>
+export interface LegacyResolverV1<T> {
+  interfaceVersion?: 1
+  resolveImport: LegacyResolverResolveImport<T>
 }
+
+export interface LegacyResolverV2<T> {
+  interfaceVersion: 2
+  resolve: LegacyResolverResolve<T>
+}
+
+export type LegacyResolver<T = unknown, U = T> =
+  | LegacyResolverV1<U>
+  | LegacyResolverV2<T>
 
 export interface LegacyResolverObjectBase {
   // node, typescript, webpack...


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Refines `LegacyResolver` typing by splitting it into `LegacyResolverV1` and `LegacyResolverV2` for improved type safety.
> 
>   - **Typing Changes**:
>     - Split `LegacyResolver` into `LegacyResolverV1` and `LegacyResolverV2` in `types.ts`.
>     - `LegacyResolverV1` includes `interfaceVersion?: 1` and `resolveImport`.
>     - `LegacyResolverV2` includes `interfaceVersion: 2` and `resolve`. 
>     - Updated `LegacyResolver` type to be a union of `LegacyResolverV1` and `LegacyResolverV2`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-import-context&utm_source=github&utm_medium=referral)<sup> for 2bc6d941cf28ff6fe4f3d3be2943e636d798b955. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved typing for legacy resolver functionality, ensuring clearer distinction between supported versions.
- **Chores**
  - Added documentation for the patch update regarding legacy resolver typing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->