### PR TITLE
fix(types): incorrect and unfinished `NodeResolverOptions` typing

### DIFF
--- a/.changeset/swift-carrots-heal.md
+++ b/.changeset/swift-carrots-heal.md
@@ -1,0 +1,5 @@
+---
+"eslint-import-context": patch
+---
+
+fix(types): incorrect and unfinished `NodeResolverOptions` typing

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "yarn-berry-deduplicate": "^6.1.3"
   },
   "resolutions": {
+    "eslint-import-context": "link:.",
     "prettier": "^3.5.3"
   },
   "typeCoverage": {

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,10 +37,45 @@ export type Resolver = LegacyResolver | NewResolver
 
 export type ResolvedResult = ResultFound | ResultNotFound
 
-export interface NodeResolverOptions {
-  extensions?: readonly string[]
-  moduleDirectory?: string[]
-  paths?: string[]
+// based on https://github.com/DefinitelyTyped/DefinitelyTyped/blob/157f2565d64cbc03165a2284bf0e5176af18d991/types/resolve/index.d.ts#L93-L122
+export interface NodeResolverOptions
+  extends Omit<NapiResolveOptions, 'extensions'> {
+  /** Directory to begin resolving from (defaults to __dirname) */
+  basedir?: string
+  /** Set to false to exclude node core modules (e.g. fs) from the search */
+  includeCoreModules?: boolean
+  /** Array of file extensions to search in order (defaults to ['.js']) */
+  extensions?: string | readonly string[]
+  /**
+   * Require.paths array to use if nothing is found on the normal node_modules
+   * recursive walk (probably don't use this)
+   */
+  paths?: string | readonly string[]
+  /**
+   * Directory (or directories) in which to recursively look for modules.
+   * (default to 'node_modules')
+   */
+  moduleDirectory?: string | readonly string[]
+  /**
+   * If true, doesn't resolve `basedir` to real path before resolving. This is
+   * the way Node resolves dependencies when executed with the
+   * --preserve-symlinks flag.
+   *
+   * Note: this property is currently true by default but it will be changed to
+   * false in the next major version because Node's resolution algorithm does
+   * not preserve symlinks by default.
+   */
+  preserveSymlinks?: boolean
+
+  // The following options are not supported anymore, but kept for compatibility
+  /** @deprecated */
+  package?: unknown
+  /** @deprecated */
+  packageFilter?: unknown
+  /** @deprecated */
+  pathFilter?: unknown
+  /** @deprecated */
+  packageIterator?: unknown
 }
 
 export interface WebpackResolverOptions {
@@ -126,7 +161,7 @@ export interface LegacyResolverRecord {
   [resolve: string]: unknown
   node?: NodeResolverOptions | boolean
   typescript?: TsResolverOptions | boolean
-  webpack?: WebpackResolverOptions
+  webpack?: WebpackResolverOptions | boolean
 }
 
 export type LegacyImportResolver =

--- a/yarn.lock
+++ b/yarn.lock
@@ -7323,7 +7323,7 @@ __metadata:
   languageName: node
   linkType: soft
 
-"eslint-import-context@npm:^0.1.3, eslint-import-context@npm:^0.1.4, eslint-import-context@workspace:.":
+"eslint-import-context@workspace:.":
   version: 0.0.0-use.local
   resolution: "eslint-import-context@workspace:."
   dependencies:


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Fixes and completes `NodeResolverOptions` typing in `types.ts`, and updates `eslint-import-context` resolution in `package.json`.
> 
>   - **Types**:
>     - Corrects and completes `NodeResolverOptions` typing in `types.ts`, adding properties like `basedir`, `includeCoreModules`, `extensions`, `paths`, `moduleDirectory`, and `preserveSymlinks`.
>     - Marks `package`, `packageFilter`, `pathFilter`, and `packageIterator` as deprecated in `NodeResolverOptions`.
>   - **Package**:
>     - Adds `eslint-import-context` resolution in `package.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=un-ts%2Feslint-import-context&utm_source=github&utm_medium=referral)<sup> for dd3ac5c6bb86d24156b755c667ef414776c286db. You can [customize](https://app.ellipsis.dev/un-ts/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the accuracy and completeness of type definitions for configuration options, ensuring more reliable and predictable behavior.

- **Chores**
	- Updated package resolution to use a local version of a dependency, enhancing development workflow consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->